### PR TITLE
prepare for vgrid catalog bridge

### DIFF
--- a/vGrid/v-grid-atts.js
+++ b/vGrid/v-grid-atts.js
@@ -5,7 +5,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, customAttribute, Optional} from 'aurelia-framework';
+import {customAttribute} from 'aurelia-templating';
+import {inject, Optional} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-atts.js
+++ b/vGrid/v-grid-atts.js
@@ -6,7 +6,7 @@
  *
  ****************************************************************************************************************/
 import {inject, customAttribute, Optional} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 var VGridAttibutes = class {

--- a/vGrid/v-grid-col.js
+++ b/vGrid/v-grid-col.js
@@ -6,7 +6,7 @@
  ****************************************************************************************************************/
 
 import {inject, Optional, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 @customElement('v-grid-col')
 @inject(Element, VGrid)

--- a/vGrid/v-grid-col.js
+++ b/vGrid/v-grid-col.js
@@ -5,7 +5,8 @@
  *
  ****************************************************************************************************************/
 
-import {inject, Optional, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject, Optional} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 @customElement('v-grid-col')

--- a/vGrid/v-grid-contextmenu.js
+++ b/vGrid/v-grid-contextmenu.js
@@ -1,9 +1,10 @@
+import {customAttribute} from 'aurelia-templating';
+import {inject, Optional} from 'aurelia-dependency-injection';
+import {VGridCellRowHeader} from './v-grid-header-col';
+import {VGridCellContainer} from './v-grid-row-col';
+
 //main idea/source https://github.com/callmenick/Custom-Context-Menu
 //just testing atm, not done in any way, will need to do a few chamges, just added some to test more
-
-import {inject, customAttribute, Optional} from 'aurelia-framework';
-import {VGridCellRowHeader} from './v-grid-header-col'
-import {VGridCellContainer} from './v-grid-row-col'
 
 
 

--- a/vGrid/v-grid-generator.js
+++ b/vGrid/v-grid-generator.js
@@ -1,4 +1,4 @@
-import {ViewSlot} from 'aurelia-framework';
+import {ViewSlot} from 'aurelia-templating';
 
 
 /*****************************************************************************************************************

--- a/vGrid/v-grid-header-cells-filter-checkbox.js
+++ b/vGrid/v-grid-header-cells-filter-checkbox.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 @customElement('v-grid-filter-checkbox')

--- a/vGrid/v-grid-header-cells-filter-checkbox.js
+++ b/vGrid/v-grid-header-cells-filter-checkbox.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-header-cells-filter-selection.js
+++ b/vGrid/v-grid-header-cells-filter-selection.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 @customElement('v-grid-filter-selection')

--- a/vGrid/v-grid-header-cells-filter-selection.js
+++ b/vGrid/v-grid-header-cells-filter-selection.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-header-cells-filter-text.js
+++ b/vGrid/v-grid-header-cells-filter-text.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 @customElement('v-grid-filter-text')

--- a/vGrid/v-grid-header-cells-filter-text.js
+++ b/vGrid/v-grid-header-cells-filter-text.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-header-cells-label.js
+++ b/vGrid/v-grid-header-cells-label.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 @customElement('v-grid-label')

--- a/vGrid/v-grid-header-cells-label.js
+++ b/vGrid/v-grid-header-cells-label.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-header-col.js
+++ b/vGrid/v-grid-header-col.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, noView, customElement, processContent, Container, bindable, ViewSlot} from 'aurelia-framework';
+import {noView, customElement, processContent, bindable, ViewSlot} from 'aurelia-templating';
+import {inject, Container} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 //should I make this into a container and have cells under it?
 

--- a/vGrid/v-grid-header-col.js
+++ b/vGrid/v-grid-header-col.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, noView, customElement, processContent, Container, bindable, ViewSlot} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 //should I make this into a container and have cells under it?
 
 

--- a/vGrid/v-grid-row-cells-checkbox.js
+++ b/vGrid/v-grid-row-cells-checkbox.js
@@ -7,7 +7,8 @@
 
 //keeping one for each, so its easier to maintain if I do something special later
 
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-row-cells-checkbox.js
+++ b/vGrid/v-grid-row-cells-checkbox.js
@@ -8,7 +8,7 @@
 //keeping one for each, so its easier to maintain if I do something special later
 
 import {inject, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 /*******************************************

--- a/vGrid/v-grid-row-cells-image.js
+++ b/vGrid/v-grid-row-cells-image.js
@@ -7,7 +7,8 @@
 
 //keeping one for each, so its easier to maintain if I do something special later
 
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-row-cells-image.js
+++ b/vGrid/v-grid-row-cells-image.js
@@ -8,7 +8,7 @@
 //keeping one for each, so its easier to maintain if I do something special later
 
 import {inject, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 /*******************************************

--- a/vGrid/v-grid-row-cells-input.js
+++ b/vGrid/v-grid-row-cells-input.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 @customElement('v-grid-input')

--- a/vGrid/v-grid-row-cells-input.js
+++ b/vGrid/v-grid-row-cells-input.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-row-cells-selection.js
+++ b/vGrid/v-grid-row-cells-selection.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, customElement, bindable} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 @customElement('v-grid-selection')
@@ -82,4 +82,3 @@ export class VGridRowCellSelection {
 
   }
 }
-

--- a/vGrid/v-grid-row-cells-selection.js
+++ b/vGrid/v-grid-row-cells-selection.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {bindable, customElement} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-row-col.js
+++ b/vGrid/v-grid-row-col.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, noView, customElement, processContent, Container, bindable, ViewSlot} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 @noView()

--- a/vGrid/v-grid-row-col.js
+++ b/vGrid/v-grid-row-col.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, noView, customElement, processContent, Container, bindable, ViewSlot} from 'aurelia-framework';
+import {noView, customElement, processContent, bindable, ViewSlot} from 'aurelia-templating';
+import {inject, Container} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid-row-repeat.js
+++ b/vGrid/v-grid-row-repeat.js
@@ -5,7 +5,7 @@
  *
  ****************************************************************************************************************/
 import {inject, noView, customElement, processContent, Container, bindable, ViewSlot} from 'aurelia-framework';
-import {VGrid} from './v-grid'
+import {VGrid} from './v-grid';
 
 
 @noView()

--- a/vGrid/v-grid-row-repeat.js
+++ b/vGrid/v-grid-row-repeat.js
@@ -4,7 +4,8 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {inject, noView, customElement, processContent, Container, bindable, ViewSlot} from 'aurelia-framework';
+import {noView, customElement, processContent, bindable, ViewSlot} from 'aurelia-templating';
+import {inject, Container} from 'aurelia-dependency-injection';
 import {VGrid} from './v-grid';
 
 

--- a/vGrid/v-grid.js
+++ b/vGrid/v-grid.js
@@ -5,7 +5,7 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {bindable, ViewSlot, ViewCompiler, ViewResources, containerless} from 'aurelia-templating';
+import {bindable, ViewSlot, ViewCompiler, ViewResources} from 'aurelia-templating';
 import {TaskQueue} from 'aurelia-task-queue';
 import {ObserverLocator} from 'aurelia-binding';
 import {Container} from 'aurelia-dependency-injection';

--- a/vGrid/v-grid.js
+++ b/vGrid/v-grid.js
@@ -5,7 +5,11 @@
  *    Created by vegar ringdal
  *
  ****************************************************************************************************************/
-import {TaskQueue, ObserverLocator, bindable, ViewCompiler, ViewSlot, Container, ViewResources, containerless} from 'aurelia-framework';
+import {bindable, ViewSlot, ViewCompiler, ViewResources, containerless} from 'aurelia-templating';
+import {TaskQueue} from 'aurelia-task-queue';
+import {ObserverLocator} from 'aurelia-binding';
+import {Container} from 'aurelia-dependency-injection';
+
 import {VGridGenerator} from './v-grid-generator';
 import {VGridFilter} from './v-grid-filter';
 import {VGridSort} from './v-grid-sort';
@@ -23,13 +27,13 @@ export class VGrid {
   @bindable({attribute: "v-grid-context"}) vGridContextObj;
   @bindable({attribute: "v-collection"}) vGridCollection;
   @bindable({attribute: "v-current-entity"}) vGridCurrentEntity;
-  
+
   //loading screen when filtering/sorting
   @bindable loadingMessage = "Working please wait";
   loading = false;
 
   constructor(element, observerLocator, viewCompiler, viewSlot, container, viewResources, taskQueue) {
-    
+
     //<v-grid> element
     this.element = element;
 


### PR DESCRIPTION
Added semicolons to vgrid imports since the dts generator cannot really cope with missing semicolons.

Removed references to aurelia-framework and imported from single modules. This way, the resulting library does not pull all of aurelia-framework but only the parts it needs.

This change may break the demo, I'm not sure. For me it worked. If it breaks, just install the missing aurelia dependencies. They have to be top-level in jspm config.
